### PR TITLE
Adding ability to handle webhooks from Github

### DIFF
--- a/example.config
+++ b/example.config
@@ -10,5 +10,7 @@ valid_containers = {'docker_user/image_name':
                       {'tag': 'main', 'target': 'target_dir/update'},
                       {'tag': 'test', 'target': 'test_dir/update'}],
                     'other_user/other_name':
-                      [{'tag': 'stable-.+', 'target': 'other_target_dir/update'}]
+                      [{'tag': 'stable-.+', 'target': 'other_target_dir/update'}],
+                    'gh_user/repo_name':
+                     [{'tag': 'refs/heads/main', 'target': 'target_dir/update'}]
                    }

--- a/test_forklift.py
+++ b/test_forklift.py
@@ -46,13 +46,17 @@ def test_hook_success(mocker):
     assert app.post_json('/hook?apikey=12345', data).status == '200 OK'
     subprocess.check_output.assert_called_once_with('/srv/docker/target_dir/update')
 
+def test_gh_hook_success(mocker):
+    mocker.patch('subprocess.check_output', return_value="Mocked subprocess call success")
+    data = {'ref': 'refs/heads/main', 'repository': {'full_name': 'gh_user/repo_name'}}
+    assert app.post_json('/gh_hook?apikey=12345', data, headers={'X-GitHub-Event': 'push'}).status == '200 OK'
+    subprocess.check_output.assert_called_once_with('/srv/docker/target_dir/update')
 
 def test_hook_success_alt_tag(mocker):
     mocker.patch('subprocess.check_output', return_value="Mocked subprocess call success")
     data = {'push_data': {'tag': 'main'}, 'repository': {'repo_name': 'docker_user/image_name'}}
     assert app.post_json('/hook?apikey=12345', data).status == '200 OK'
     subprocess.check_output.assert_called_once_with('/srv/docker/target_dir/update')
-
 
 def test_hook_success_other_regexp(mocker):
     mocker.patch('subprocess.check_output', return_value="Mocked subprocess call success")


### PR DESCRIPTION
#### Overview
We would like to use forklift for automating deployments of things that are not running in containers.  Since a webhook would never be called from DockerHub in those cases, we could call from Github webhooks instead.

This adds an additional endpoint that can parse the format of a GH event payload.  It currently only handles the push event, but the event type is being detected so it could be expanded on to handle the many various events GH can send.

Any repo that wants to send an event payload back to forklift from GH would have to use the new endpoint like:

`https://location_of_forklift.domain.com/gh_webhook?apikey=xxxxxxxxxxxxx` 

#### Configuration
The configuration of the `valid_containers` section requires knowing how to map the data in the GH event payload to the name and tag values.  For the following payload:
```
{
  "ref": "refs/heads/main",
...
  "repository": {
    "id": 176407102,
...
    "name": "some_repo",
    "full_name": "IUBLibTech/some_repo"
  }  
}
```
The values in the forklift configuration would be:
```
valid_containers = {'IUBLibTech/some_repo':
                     [{'tag': 'refs/heads/main', 
                       'target': 'some_deployment_location/bin/update'}]
                   }
```