### PR TITLE
Add support for github package events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # forklift
 [![Python application](https://github.com/IUBLibTech/forklift/actions/workflows/python-app.yml/badge.svg)](https://github.com/IUBLibTech/forklift/actions/workflows/python-app.yml)
 
-Listener for Docker Hub webhooks.
+Listener for Docker Hub and Github webhooks.
 
 ## Installation
 `pip install -r requirements.txt`

--- a/example.config
+++ b/example.config
@@ -12,5 +12,6 @@ valid_containers = {'docker_user/image_name':
                     'other_user/other_name':
                       [{'tag': 'stable-.+', 'target': 'other_target_dir/update'}],
                     'gh_user/repo_name':
-                     [{'tag': 'refs/heads/main', 'target': 'target_dir/update'}]
+                     [{'tag': 'refs/heads/main', 'target': 'target_dir/update'},
+                      {'tag': 'latest', 'target': 'target_dir/package_update'}]
                    }

--- a/test_forklift.py
+++ b/test_forklift.py
@@ -46,11 +46,22 @@ def test_hook_success(mocker):
     assert app.post_json('/hook?apikey=12345', data).status == '200 OK'
     subprocess.check_output.assert_called_once_with('/srv/docker/target_dir/update')
 
-def test_gh_hook_success(mocker):
+def test_gh_hook_push_success(mocker):
     mocker.patch('subprocess.check_output', return_value="Mocked subprocess call success")
     data = {'ref': 'refs/heads/main', 'repository': {'full_name': 'gh_user/repo_name'}}
     assert app.post_json('/gh_hook?apikey=12345', data, headers={'X-GitHub-Event': 'push'}).status == '200 OK'
     subprocess.check_output.assert_called_once_with('/srv/docker/target_dir/update')
+
+def test_gh_hook_package_success(mocker):
+    mocker.patch('subprocess.check_output', return_value="Mocked subprocess call success")
+    data = {'container_metadata': {'tag': {'name': 'latest'}}, 'repository': {'full_name': 'gh_user/repo_name'}}
+    assert app.post_json('/gh_hook?apikey=12345', data, headers={'X-GitHub-Event': 'package'}).status == '200 OK'
+    subprocess.check_output.assert_called_once_with('/srv/docker/target_dir/package_update')
+
+def test_gh_hook_bad_event(mocker):
+    mocker.patch('subprocess.check_output', return_value="Mocked subprocess call success")
+    data = {'container_metadata': {'tag': {'name': 'latest'}}, 'repository': {'full_name': 'gh_user/repo_name'}}
+    assert app.post_json('/gh_hook?apikey=12345', data, expect_errors=True, headers={'X-GitHub-Event': 'badevent'}).status == '400 Bad Request'
 
 def test_hook_success_alt_tag(mocker):
     mocker.patch('subprocess.check_output', return_value="Mocked subprocess call success")


### PR DESCRIPTION
Github webhooks for package events have a different json payload, this expands the `gh_hook` route to support it. Event types other than `push` and `package` will be ignored.